### PR TITLE
chore: add badges to README

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,12 @@
-name: Pull Request Checks
+name: CI
 
 on:
   pull_request:
+    branches:
+      - main
+  # Also run on push to main so the CI badge in the README reflects the
+  # actual test status of the main branch
+  push:
     branches:
       - main
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Display multiple progress bars in an Electron window.
 
+[![npm version](https://img.shields.io/npm/v/@spaceagetv/electron-progress-window)](https://www.npmjs.com/package/@spaceagetv/electron-progress-window)
+[![npm downloads](https://img.shields.io/npm/dm/@spaceagetv/electron-progress-window)](https://www.npmjs.com/package/@spaceagetv/electron-progress-window)
+[![Tests](https://github.com/spaceagetv/electron-progress-window/actions/workflows/pull_request.yml/badge.svg)](https://github.com/spaceagetv/electron-progress-window/actions/workflows/pull_request.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Node.js](https://img.shields.io/node/v/@spaceagetv/electron-progress-window)](https://nodejs.org/)
+
 ## Advantages
 
 * Full Typescript support, including event types


### PR DESCRIPTION
This pull request updates the CI workflow and improves project documentation by adding useful badges to the `README.md`. These changes make the repository status more visible and ensure that the CI badge accurately reflects the status of the main branch.

**Documentation improvements:**

* Added several badges to the top of `README.md`, including npm version, downloads, test status, license, TypeScript version, and Node.js version.

**Continuous Integration (CI) workflow updates:**

* Renamed the workflow from "Pull Request Checks" to "CI" and updated `.github/workflows/pull_request.yml` to also run on pushes to the `main` branch, ensuring the CI badge in the README reflects the current status of the main branch.